### PR TITLE
FeatureBackend.Set must now return an error

### DIFF
--- a/backends/memory/memory.go
+++ b/backends/memory/memory.go
@@ -41,6 +41,7 @@ func (imb *InMemoryBackend) Open(interface{}) error {
 }
 
 // Set will create a feature given a feature name and a wave.Feature.
-func (imb *InMemoryBackend) Set(name string, feature *wave.Feature) {
+func (imb *InMemoryBackend) Set(name string, feature *wave.Feature) error {
 	imb.features[name] = feature
+	return nil
 }

--- a/feature_backend.go
+++ b/feature_backend.go
@@ -29,5 +29,5 @@ type FeatureBackend interface {
 	// Set is called by a Wave instance in order to add a feature to the
 	// backend. The first argument is the feature name and the second is
 	// the feature.
-	Set(string, *Feature)
+	Set(string, *Feature) error
 }

--- a/wave.go
+++ b/wave.go
@@ -18,8 +18,8 @@ func NewWave(backend FeatureBackend) *Wave {
 }
 
 // AddFeature adds a Feature to the wave instance.
-func (r *Wave) AddFeature(feature *Feature) {
-	r.storage.Set(feature.Name, feature)
+func (r *Wave) AddFeature(feature *Feature) error {
+	return r.storage.Set(feature.Name, feature)
 }
 
 // Can returns true of the given user has access to the given feature.

--- a/wave_utilities_test.go
+++ b/wave_utilities_test.go
@@ -11,6 +11,7 @@ import (
 type testingBackend struct {
 	Features map[string]*wave.Feature
 	CloseSideEffect error
+	SetSideEffect error
 }
 
 func newTestingBackend() *testingBackend {
@@ -36,8 +37,9 @@ func (tb *testingBackend) Get(name string) (*wave.Feature, error) {
 	return nil, wave.ErrFeatureNotFound
 }
 
-func (tb *testingBackend) Set(name string, feature *wave.Feature) {
+func (tb *testingBackend) Set(name string, feature *wave.Feature) error {
 	tb.Features[name] = feature
+	return tb.SetSideEffect
 }
 
 // USER INFORMATION FOR TESTING


### PR DESCRIPTION
Returning an error is usually needed for databases or other persistent backends to realistically work.